### PR TITLE
Fix link stuff

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! This library can help you generate libtool archive files to link
 //! with existing C library.
-//! 
+//!
 //! Add this to Config.toml
 //!
 //! ```toml
@@ -27,8 +27,8 @@
 //! It will automatically generate the file `target/{profile}/libfoo.la`
 
 use std::env;
-use std::fs::File;
 use std::fs;
+use std::fs::File;
 use std::io::prelude::*;
 use std::os::unix::fs::symlink;
 use std::path::PathBuf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,7 @@ pub fn generate_convenience_lib(lib: &str) -> std::io::Result<()> {
     if la_path.exists() {
         fs::remove_file(&la_path)?;
     }
-    if new_lib_path.exists() {
-        fs::remove_file(&new_lib_path)?;
-    }
+    let _ = fs::remove_file(&new_lib_path);
 
     let mut file = File::create(&la_path)?;
     writeln!(file, "# {}.la - a libtool library file", lib)?;


### PR DESCRIPTION
The std::fs::PathBuf::exists() traverses symlinks, so it will return false if
the link exists, but the library it points to is missing.  So to fix this it's
easier to just remove the symlink and don't care about the error.