### PR TITLE
Fix possible errors when rebuilding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! This library can help you generate libtool archive files to link
 //! with existing C library.
-//! 
+//!
 //! Add this to Config.toml
 //!
 //! ```toml
@@ -27,8 +27,8 @@
 //! It will automatically generate the file `target/{profile}/libfoo.la`
 
 use std::env;
-use std::fs::File;
 use std::fs;
+use std::fs::File;
 use std::io::prelude::*;
 use std::os::unix::fs::symlink;
 use std::path::PathBuf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,7 @@ pub fn generate_convenience_lib(lib: &str) -> std::io::Result<()> {
     if la_path.exists() {
         fs::remove_file(&la_path)?;
     }
-    if new_lib_path.exists() {
-        fs::remove_file(&new_lib_path)?;
-    }
+    let _ = fs::remove_file(&new_lib_path);
 
     let mut file = File::create(&la_path)?;
     writeln!(file, "# {}.la - a libtool library file", lib)?;


### PR DESCRIPTION
This is a simple fix of #2 before which I also formatted the code with `rustfmt` and removed trailing whitespaces.